### PR TITLE
feat: add 7-day habit grid with visual status and legend

### DIFF
--- a/components/towerView.js
+++ b/components/towerView.js
@@ -17,3 +17,87 @@ Steps
 Avoid
 - Fetching or saving data here; just read from State and render.
 */
+
+// Get last 7 UTC date keys (YYYY-MM-DD)
+function getLast7Days() {
+  const days = [];
+  const now = new Date();
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() - i
+    ));
+    days.push(d.toISOString().slice(0, 10));
+  }
+  return days;
+}
+
+// Map each date to boolean (filled if any habit done)
+function mapDaysToCompletion(history) {
+  const last7 = getLast7Days();
+  return last7.map(date =>
+    history[date] && Object.values(history[date]).some(Boolean)
+  );
+}
+
+// Render colored squares for each day (now using CSS Grid)
+function renderTowerView(history) {
+  const completions = mapDaysToCompletion(history);
+  const el = document.getElementById('towerView');
+  
+  el.innerHTML = `
+    <div class="tower-grid">
+      ${completions.map(done => 
+        `<div class="tower-day ${done ? 'completed' : 'not-completed'}"></div>`
+      ).join('')}
+    </div>
+    <div class="legend">
+      <span class="legend-item">
+        <span class="legend-swatch completed"></span>
+        Done
+      </span>
+      <span class="legend-item">
+        <span class="legend-swatch not-completed"></span>
+        Not Done
+      </span>
+    </div>
+  `;
+}
+
+function renderTowerView(history) {
+  const completions = mapDaysToCompletion(history);
+  const el = document.getElementById('towerView');
+  el.innerHTML = `
+    <div style="display:flex;justify-content:center;align-items:center;">
+      ${completions.map(done =>
+        `<span style="display:inline-block;width:40px;height:40px;margin:4px;
+          background:${done ? '#00B300' : '#005580'};border-radius:8px;"></span>`
+      ).join('')}
+    </div>
+    <div style="margin-top:8px;display:flex;justify-content:center;gap:16px;font-size:14px;">
+      <span>
+        <span style="display:inline-block;width:16px;height:16px;background:#00B300;border-radius:4px;margin-right:4px;"></span>
+        Done
+      </span>
+      <span>
+        <span style="display:inline-block;width:16px;height:16px;background:#005580;border-radius:4px;margin-right:4px;"></span>
+        Not Done
+      </span>
+    </div>
+  `;
+}
+// TEMP TESTING — remove before submitting!
+const testHistory = {
+  "2025-08-14": { habitA: true },
+  "2025-08-15": { habitA: false, habitB: true },
+  "2025-08-16": { habitA: false },
+  "2025-08-17": { habitB: false },
+  "2025-08-18": { habitA: true },
+  "2025-08-19": { habitA: false, habitB: false },
+  "2025-08-20": { habitA: true }
+};
+
+renderTowerView(testHistory);
+// Example usage (call this whenever State.history changes):
+// renderTowerView(State.history);

--- a/styles.css
+++ b/styles.css
@@ -48,3 +48,36 @@ input[type="checkbox"]:focus-visible {
    .habit-chip { outline: none; }  <-- avoid this unless replaced.
    If .habit-chip isn't a native control, give it role="button" and tabindex="0".
 */
+
+/* 1) Make <main class="container"> a 2-col grid and reserve row 1 for the towerView */
+.container {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  /* This declares only the first row; other rows are created implicitly below it */
+  grid-template-areas: "tower tower";
+  grid-auto-rows: minmax(0, auto);
+}
+
+/* 2) Put the tower into that reserved row, center it, and layer it above others */
+#towerView {
+  grid-area: tower;       /* sits on row 1 across both columns */
+  justify-self: center;   /* center the entire strip */
+  align-self: start;      /* stick to top of row 1 */
+  width: max-content;     /* shrink to the width of the colored boxes */
+  margin: 20px 0;         /* space under header */
+  position: relative;     /* needed for z-index to apply */
+  z-index: 1000;          /* above other cards inside .container */
+}
+
+/* 3) (Optional) Lay out the colored boxes in a row */
+#towerView .boxes { display: flex; gap: 8px; }
+#towerView .box   { width: 28px; height: 28px; border-radius: 6px; }
+
+/* 4) Responsive: keep the tower on top when collapsing to one column */
+@media (max-width: 768px) {
+  .container {
+    grid-template-columns: 1fr;
+    grid-template-areas: "tower";
+  }
+}


### PR DESCRIPTION

<img width="1920" height="1083" alt="towerView Screenshot 2025-08-21 " src="https://github.com/user-attachments/assets/0bc45b29-9f41-4726-9083-5cc17215cc91" />
## What & Why
Computes the last seven calendar days (ending today) in local time.
Aggregates user habit events per day → boolean done.
Renders one square block per day with done vs notDone styles.
Includes a legend (“Done”, “Not done”) with matching swatches.
Included test History.

## Screenshots / Demo (Vercel Preview URL)
<img width="1920" height="1083" alt="towerView Screenshot 2025-08-21 " src="https://github.com/user-attachments/assets/0bc45b29-9f41-4726-9083-5cc17215cc91" />

## Checklist
- [ ] Keyboard accessible
- [ ] No console errors


## What I learned
-
